### PR TITLE
1.0.14以前対応のミス修正（キャメルケースに変更）

### DIFF
--- a/assets/modules/cfFormDB/cfformdb.class.php
+++ b/assets/modules/cfFormDB/cfformdb.class.php
@@ -52,7 +52,7 @@ class cfFormDB {
         }
     }
 
-    $this->modx->loadExtension('maketable');
+    $this->modx->loadExtension('MakeTable');
   }
 
   /**


### PR DESCRIPTION
1.0.14Jでエラーになったので確認したところミスがありました。すみません。
